### PR TITLE
fix(cadastros): Ajuste de validações nos cadastros de aluno e empresa

### DIFF
--- a/implementacao/api/package-lock.json
+++ b/implementacao/api/package-lock.json
@@ -17,6 +17,7 @@
         "@nestjs/platform-express": "^10.0.0",
         "@prisma/client": "^5.4.1",
         "azure-storage": "^2.10.7",
+        "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
         "nodemailer": "^6.9.7",
         "reflect-metadata": "^0.1.13",
@@ -3433,6 +3434,11 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
       "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
       "dev": true
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
     },
     "node_modules/class-validator": {
       "version": "0.14.0",

--- a/implementacao/api/package.json
+++ b/implementacao/api/package.json
@@ -28,6 +28,7 @@
     "@nestjs/platform-express": "^10.0.0",
     "@prisma/client": "^5.4.1",
     "azure-storage": "^2.10.7",
+    "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "nodemailer": "^6.9.7",
     "reflect-metadata": "^0.1.13",

--- a/implementacao/api/src/modules/aluno/aluno.controller.ts
+++ b/implementacao/api/src/modules/aluno/aluno.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post, Get, Param } from '@nestjs/common';
+import { Body, Controller, Post, Get, Param, UsePipes, ValidationPipe } from '@nestjs/common';
 import { CadastroAlunoDTO } from './dto/CadastroAluno.dto';
 import { AlunoService } from './aluno.service';
 import { Aluno, Transacao, Vantagem } from '@prisma/client';
@@ -9,12 +9,14 @@ export class AlunoController {
   constructor(private readonly alunoService: AlunoService) { }
 
   @Post()
+  @UsePipes(new ValidationPipe())
   async cadastrarAluno(@Body() alunoDTO: CadastroAlunoDTO): Promise<{ success: boolean }> {
     await this.alunoService.cadastrarAluno(alunoDTO);
     return { success: true };
   }
 
   @Post('comprar-vantagem/:nomeUsuario')
+  @UsePipes(new ValidationPipe())
   async comprarVantagem(@Param('nomeUsuario') nomeUsuario, @Body() compraVantagemDTO: CompraVantagemDTO): Promise<{ success: boolean }> {
     await this.alunoService.comprarVantagem(nomeUsuario, compraVantagemDTO.vantagemId);
     return { success: true };

--- a/implementacao/api/src/modules/aluno/dto/CadastroAluno.dto.ts
+++ b/implementacao/api/src/modules/aluno/dto/CadastroAluno.dto.ts
@@ -1,32 +1,39 @@
-import { IsInt, IsString, MaxLength } from "class-validator";
+import { IsInt, IsNotEmpty, IsString, MaxLength } from "class-validator";
 
 export class CadastroAlunoDTO {
   @IsString()
   @MaxLength(251)
+  @IsNotEmpty()
   nome: string;
 
   @IsString()
   @MaxLength(11)
+  @IsNotEmpty()
   cpf: string;
 
   @IsString()
   @MaxLength(10)
+  @IsNotEmpty()
   rg: string;
 
   @IsString()
   @MaxLength(251)
+  @IsNotEmpty()
   email: string;
 
   @IsString()
   @MaxLength(251)
+  @IsNotEmpty()
   endereco: string;
 
   @IsString()
   @MaxLength(251)
+  @IsNotEmpty()
   nomeUsuario: string;
 
   @IsString()
   @MaxLength(251)
+  @IsNotEmpty()
   senha: string;
 
   @IsInt()

--- a/implementacao/api/src/modules/empresa/empresa.controller.ts
+++ b/implementacao/api/src/modules/empresa/empresa.controller.ts
@@ -4,6 +4,8 @@ import {
   Post,
   Body,
   Param,
+  UsePipes,
+  ValidationPipe,
 } from '@nestjs/common';
 import { EmpresaService } from './empresa.service';
 import { CreateEmpresaDto } from './dto/CadastroEmpresa.dto';
@@ -15,6 +17,7 @@ export class EmpresaController {
   constructor(private readonly empresaService: EmpresaService) {}
 
   @Post()
+  @UsePipes(new ValidationPipe())
   async cadastrarEmpresa(@Body() createEmpresaDto: CreateEmpresaDto):Promise<{success: boolean}> {
     await this.empresaService.create(createEmpresaDto);
     return {success: true};

--- a/implementacao/views/src/pages/cadastroAluno/index.jsx
+++ b/implementacao/views/src/pages/cadastroAluno/index.jsx
@@ -47,6 +47,18 @@ const CadastroAluno = () => {
   const handleSubmit = useCallback(
     async (e) => {
       e.preventDefault();
+
+      let isFormularioValido = Object.values(formData).every(value => value.trim() !== '');
+
+      if (!isFormularioValido) {
+        Swal.fire({
+          icon: 'error',
+          title: 'Oops...',
+          text: 'Por favor, preencha todos os campos',
+        });
+        return;
+      }
+
       try {
         console.log({ ...formData, cursoId: curso.id, instituicaoId: curso.instituicaoId })
         const resposta = await useApi.post("/aluno", { ...formData, cursoId: curso.id, instituicaoId: curso.instituicaoId });


### PR DESCRIPTION
Foram feitas 2 modificações para validar os dados nos cadastros de aluno e empresa:
- Antes era possível realizar o cadastro de alunos sem informar dados como email, senha, cpf e etc, foi adicionada uma validação do formulário no frontend para enviar os dados apenas quando tudo estiver preenchido
- Antes existiam validações nos DTO's (@IsString, por exemplo), mas para que essas validações fizessem efeito, faltava adicionar nas controllers o _@UsePipes(new ValidationPipe())_, adicionei apenas nas rotas do aluno e empresa que possuíam validações no body, mas seria interessante adicionar nas demais controllers também
- Adicionei também a validação _is not empty_ nos dados obrigatórios do cadastro de alunos, para evitar que caso venha uma string vazia ele permita o cadastro
- Para usar o ValidationPipe precisei adicionar uma nova dependência no backend (class-transformer)