### PR TITLE
fix(tratativa-erros): Ajuste na mensagem de erro ao resgatar vantagem

### DIFF
--- a/implementacao/views/src/components/CardProduto/index.jsx
+++ b/implementacao/views/src/components/CardProduto/index.jsx
@@ -28,7 +28,7 @@ const CardProduto = ({ temBotao, vantagem }) => {
       Swal.fire({
         icon: 'error',
         title: 'Oops...',
-        text: `Erro na compra: ${error}`,
+        text: `Erro na compra: ${error.response.data.message}`,
       })
     }
   };


### PR DESCRIPTION
Ajuste na mensagem de erro exibida ao tentar resgatar vantagem com valor maior que o saldo do aluno
* Mensagem de erro anteriormente: Erro na compra: AxiosError: Request failed with status code 400
* Mensagem de erro hoje: Erro na compra: Saldo insuficiente
* Ao invés de pegar a mensagem de erro da propriedade _error_, agora pegamos do _error.response.data.message_